### PR TITLE
Bug: Duplication of Teams

### DIFF
--- a/djangoresourcemanagement/views.py
+++ b/djangoresourcemanagement/views.py
@@ -76,7 +76,8 @@ def get_teams(request):
     for team in listOfTeams:
         for squad in squadMember:
             if team.id == squad.team_id:
-                usersTeams.append(team)
+                if (not usersTeams.__contains__(team)):
+                    usersTeams.append(team)
 
     jsonResponseData = {'response': []}
     for team in usersTeams:


### PR DESCRIPTION
Edited the view Get_teams to fix the duplication of teams when displayed to profile page. Pertains to issue #24 