### PR TITLE
feat: Managers Can Edit Team

### DIFF
--- a/djangoresourcemanagement/views.py
+++ b/djangoresourcemanagement/views.py
@@ -163,6 +163,78 @@ def get_edit_team(request,team_id):
                 'role_name': SquadMembers.objects.get(team=team, user=member).role.name
             }]
 
+        if Users.objects.get(id=request.user.id).permission != 'MNGR':
+            return redirect('profile')
+        else:
+            if request.method == 'POST':
+                print(request.POST)
+                team_name = request.POST['team_name']
+                team_leader = request.POST['team_lead']
+                shrt_desc = request.POST["short_description"]
+                long_desc = request.POST["long_description"]
+                team_type = request.POST["type"]
+                projects_list = request.POST.getlist("proj")
+                squadmember_list = request.POST.getlist("personID")
+                roles_to_squadmembers = request.POST.getlist("roles")
+                members_to_delete = request.POST.getlist("member_to_delete_id")
+                projects_to_delete = request.POST.getlist("project_to_delete_id")
+
+                # if team_name == "" or team_leader == "" or shrt_desc == "" or long_desc == "" or team_type == "" or len(
+                #         projects_list) == 0 or len(squadmember_list) == 0:
+                #     return render(request, 'edit_team.html', {'Fail': "Invalid input, Make sure all fields are input",
+                #     'team': team, 'members_and_roles': members_and_roles})
+
+                editedTeam = Teams.objects.get(id=team_id)
+
+                editedTeam.name = team_name
+                editedTeam.leader = Users.objects.get(id=team_leader)
+                editedTeam.short_description = shrt_desc
+                editedTeam.description = long_desc
+                editedTeam.type = team_type
+                editedTeam.save()
+
+                print(editedTeam)
+
+                for project in projects_list:
+                    editedTeam.team_projects.add(Projects.objects.get(id=project))
+
+                for member in squadmember_list:
+                    print(member)
+                    squadMemberToAdd = SquadMembers(
+                        user=Users.objects.get(id=member),
+                        team=editedTeam,
+                        role=Roles.objects.get(id=1),
+                        description="Blank For Now"
+                    )
+                    squadMemberToAdd.save()
+
+                # deletion of members
+                for memberToDelete in members_to_delete:
+                    squadEntity = SquadMembers.objects.get(user=memberToDelete,team=team)
+                    squadEntity.delete()
+
+                # deletion of projects
+                for projectToDelete in projects_to_delete:
+                    project = Projects.objects.get(id=projectToDelete)
+                    project.teams_set.remove(team)
+
+                members_and_roles = {
+                    'members': [],
+                }
+                team = Teams.objects.get(id=team_id)
+                for member in team.team_members.all():
+                    members_and_roles['members'] += [{
+                        'member_id': member.id,
+                        'name': member.first_name + " " + member.last_name,
+                        'role_id': SquadMembers.objects.get(team=team, user=member).role.id,
+                        'role_name': SquadMembers.objects.get(team=team, user=member).role.name
+                    }]
+
+                return render(request, 'edit_team.html', {'success': "Team " + editedTeam.name + " Edited",
+                                                          'team': team, 'members_and_roles': members_and_roles})
+
+        return render(request, 'edit_team.html', {'team' : team, 'members_and_roles' : members_and_roles})
+
 def project_maker(request):
     if request.user.is_authenticated:
         if Users.objects.get(id=request.user.id).permission != 'MNGR':

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -75,3 +75,6 @@ html {
 .nav {
     display: inline;
 }
+.team_edit_link{
+
+}

--- a/static/js/teams/teamview.js
+++ b/static/js/teams/teamview.js
@@ -1,6 +1,7 @@
 $(document).ready(function(){
 
     let elementArray = document.getElementsByClassName("teams");
+    let linkArray = document.getElementsByClassName("team_edit_link");
     let showTeamElement = document.getElementById("showTeams");
     hide(elementArray, showTeamElement);
 
@@ -19,6 +20,7 @@ $(document).ready(function(){
             for (let i = 4; i < elementArray.length; i++)
             {
                 $(elementArray[i]).addClass("d-none");
+                $(linkArray[i]).addClass("d-none");
             }
         }
         showTeamElement.innerText = "Show All";
@@ -29,6 +31,7 @@ $(document).ready(function(){
         for (let i = 4; i < elementArray.length; i++)
         {
             $(elementArray[i]).removeClass("d-none");
+            $(linkArray[i]).removeClass("d-none");
         }
         showTeamElement.innerText = "Hide";
     }

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -39,17 +39,20 @@
                     <!-- content loaded from db -->
                     {% if user.is_authenticated %}
                     {% for team in usersTeams %}
-                        <button class="btn btn-primary teams mb-2" data-toggle="collapse" data-target="#{{ team.id }}">{{ team.name }}</button>
-                        <div class="collapse multi-collapse" id="{{ team.id }}">
-                            <div class="card card-body">
-                                {% if team.leader != null %}
-                                    <p>{{ team.leader }} (Lead)</p>
-                                {% endif %}
-                                {% for member in team.team_members.all %}
-                                    {% if member != team.leader %}
-                                        <p>{{member}}</p>
+                        <div class="holder">
+                            <button class="btn btn-primary teams mb-2" data-toggle="collapse" data-target="#{{ team.id }}">{{ team.name }}</button>
+                            <a href="/teammaker/edit/{{ team.id }}" class="team_edit_link">edit</a>
+                            <div class="collapse multi-collapse" id="{{ team.id }}">
+                                <div class="card card-body">
+                                    {% if team.leader != null %}
+                                        <p>{{ team.leader }} (Lead)</p>
                                     {% endif %}
-                                {% endfor %}
+                                    {% for member in team.team_members.all %}
+                                        {% if member != team.leader %}
+                                            <p>{{member}}</p>
+                                        {% endif %}
+                                    {% endfor %}
+                                </div>
                             </div>
                         </div>
                     {% endfor %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -41,7 +41,9 @@
                     {% for team in usersTeams %}
                         <div class="holder">
                             <button class="btn btn-primary teams mb-2" data-toggle="collapse" data-target="#{{ team.id }}">{{ team.name }}</button>
-                            <a href="/teammaker/edit/{{ team.id }}" class="team_edit_link">edit</a>
+                            {% if user.permission == 'MNGR' %}
+                                <a href="/teammaker/edit/{{ team.id }}" class="team_edit_link">edit</a>
+                            {% endif %}
                             <div class="collapse multi-collapse" id="{{ team.id }}">
                                 <div class="card card-body">
                                     {% if team.leader != null %}


### PR DESCRIPTION
Users with manager privileges can now edit team information including the team name, team leader, a short and long team description, the type of team (public/private), associated projects with the team, and members of the team and their roles.

Team editing can be accessed by managers through the profile page by using the "edit" button to the right of all teams.