### PR TITLE
Fix: project owner link

### DIFF
--- a/templates/project_display.html
+++ b/templates/project_display.html
@@ -19,7 +19,7 @@
     <div class = "boxDesign">
         <div>
             <p class="heading">Owner: </p>
-            <p class="paragraph"> {{info.owner}}</p>
+            <p class="paragraph"> <a href="/userDisplay/{{info.owner_id}}/">{{info.owner}}</a></p>
         </div>
         <div>
             <p class="heading">ID:</p>


### PR DESCRIPTION
Added a link to project display that takes the user to the user display of the owner. This is in accordance to issue #57 .